### PR TITLE
Address issue #9 by allowing extra list elements while still checking for essential names

### DIFF
--- a/R/spcr_check_measure_data.R
+++ b/R/spcr_check_measure_data.R
@@ -12,8 +12,8 @@ spcr_check_measure_data <- function(.data) {
   )
 
   assertthat::assert_that(
-    all(names(.data) %in% c("week", "month")),
-    msg = "spcr_check_measure_data: The list items must be from 'week' or 'month'."
+    all(c("week", "month") %in% names(.data)),
+    msg = "spcr_check_measure_data: The list must contain items named 'week' and 'month'."
   )
 
   # convert refs to character vectors

--- a/tests/testthat/test-spcr_check_measure_data.R
+++ b/tests/testthat/test-spcr_check_measure_data.R
@@ -12,6 +12,34 @@ test_that("it contains only allowed items", {
   )
 })
 
+
+"List containing extra elements is allowed" |>
+  test_that({
+    expect_no_error(
+      list(
+        week = data.frame(ref = 1),
+        month = data.frame(ref = 2),
+        asdf = data.frame(ref = 3)
+      ) |>
+        spcr_check_measure_data()
+    )
+  })
+
+"List missing either `week` or `month` causes error" |>
+  test_that({
+    expect_error(
+      list(
+        week = data.frame(ref = 1),
+        # test what happens if someone submits capitalised list element name;
+        # might be a good idea to sanitise to lower case on read in.
+        Month = data.frame(ref = 2),
+        asdf = data.frame(ref = 3)
+      ) |>
+        spcr_check_measure_data()
+    )
+  })
+
+
 measure_data <- list(
   week = tibble::tibble(
     ref = c("1", "2", "3"),


### PR DESCRIPTION
I've just reversed the logic in your assertion, to make it more permissive while still ensuring that the 'week' and 'month' sheets (or rather, list elements) exist. This may or may not be what you want!