### PR TITLE
74 fix include dq icon

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 ## Bugfix
 
+* The report now respects the `include_dq_icon` argument to `spcr_make_report`.  When set to `FALSE`, the icons are removed from both the individual metric summary rows, and from the key at the bottom of the report.
+
 ---
 
 # SPCreporter 0.2.0

--- a/inst/Rmd/Report.Rmd
+++ b/inst/Rmd/Report.Rmd
@@ -140,7 +140,10 @@ Used to summarise whether a measure is assured to meet a target.
 ![RND_TARG icon](../img/assurance_icons/RND_TARG.png) | The process is not assured, and will pass and fail the target based on variation in the process.
 ![FAIL_TARG icon](../img/assurance_icons/FAIL_TARG.png) | The process is not assured, and is likely to consistently fail to meet the target set.
 
-\newpage
+```{r results="asis"} 
+if(include_dq_icon){
+cat("
+\\newpage
 
 #### Data Quality Icons
 
@@ -152,7 +155,9 @@ Used to summarise the data quality status of a given measure, across the four do
 | ![B icon](../img/dq_icons/star_WGWW.png) | T | Timely & Complete             | Is the data available and up to date at the time of the submission or publication? Are all elements of required information present in the designated data source, and no elements need to be changed at a later date? |
 | ![C icon](../img/dq_icons/star_WWGW.png) | A | Audit & Accuracy              | Are processes in place for either external or internal audits of the data, and are these regularly scheduled (eg. quarterly, annually)? Are accuracy checks built into the data collection and reporting processes? |
 | ![D icon](../img/dq_icons/star_WWWG.png) | R | Robust systems & Data-capture | Are there robust systems which have been documented according to data dictionary standards for data capture such that it is at a sufficiently granular level? |
- 
+")}
+```
+
 :::
 
 </details>

--- a/inst/Rmd/details_template.Rmd
+++ b/inst/Rmd/details_template.Rmd
@@ -60,9 +60,10 @@
   `r ifelse("{{assurance_type}}" %in% a_labs, paste0("![{{assurance_type}} icon](", a_paths[["{{assurance_type}}"]], ")"), "{{assurance_type}}")`
 </div>
 
-<div class="spc_logo">
-  `r if ("{{data_quality}}" != "NA") "![{{data_quality}}](../img/dq_icons/star_{{data_quality}}.png)"`
-</div>
+`r ifelse(include_dq_icon, "<div class='spc_logo'>", "")`
+`r ifelse(include_dq_icon, "![{{data_quality}}](../img/dq_icons/star_{{data_quality}}.png)", "")`
+`r ifelse(include_dq_icon, "</div>", "")`
+
 </div>
 
 </div>


### PR DESCRIPTION
## Please complete the following information:

1) A reference to the issue addressed by this pull-request:  
fixes #74

2) A description of the changes proposed in this PR:  
Ensures dq icons are not included if `include_dq_icon` is set to FALSE

3) Add @mentions for the people who will review this PR:  


## Please confirm that you have:

- [x] Run `devtools::test()` and fixed all failing tests and warnings.
- [x] Added `suppressMessages()` to any test message which breaks the test progress UI.

Thank you for contributing to {SPCreporter}!!