### PR TITLE
96 report time between in days

### DIFF
--- a/R/process_event_data_t.R
+++ b/R/process_event_data_t.R
@@ -14,6 +14,7 @@ process_event_data_t <- function(event_data, data_cutoff_dttm){
       comment = NA, # remove for clarity (a comment against an event may not refer to the whole pivoted row)
       aggregation = "none"
     ) |>
+    dplyr::filter(.data$event_date_or_datetime < data_cutoff_dttm) |> # remove events after the cutoff time (should only happen for retrospective reports)
     dplyr::group_by(.data$ref) |>
     dplyr::arrange(.data$event_date_or_datetime) |>
 

--- a/R/process_event_data_t.R
+++ b/R/process_event_data_t.R
@@ -19,10 +19,11 @@ process_event_data_t <- function(event_data, data_cutoff_dttm){
 
     # add the theoretical "today" event to each group
     dplyr::group_modify(~ tibble::add_row(.x, event_date_or_datetime = data_cutoff_dttm)) |>
+
+    # calculate the time between events, in days
     dplyr::mutate(
-      time_between = .data$event_date_or_datetime - dplyr::lag(.data$event_date_or_datetime),
+      time_between = difftime(.data$event_date_or_datetime, dplyr::lag(.data$event_date_or_datetime), units = "days"),
       time_between = as.integer(.data$time_between),
-      event_date_or_datetime = as.Date(.data$event_date_or_datetime)
     ) |>
     dplyr::filter(!is.na(.data$time_between)) |>
     dplyr::ungroup() |>

--- a/tests/testthat/test-process_event_data_t.R
+++ b/tests/testthat/test-process_event_data_t.R
@@ -5,7 +5,7 @@
       "ref" = c(123, 123, 123),
       "measure_name" = "Name",
       "comment" = "comment",
-      "event_date_or_datetime" = as.Date(c("2020-01-01", "2020-01-03", "2020-01-13"))
+      "event_date_or_datetime" = as.POSIXct(c("2020-01-01", "2020-01-03", "2020-01-13"))
     )
 
     cutoff_dttm <- as.POSIXct("2020-01-31 23:59:59")
@@ -19,7 +19,7 @@
       c("aggregation", "ref", "measure_name", "comment", "date", "value")
     )
 
-    expect_equal(result[["date"]], as.Date(c("2020-01-03", "2020-01-13", "2020-01-31")))
+    expect_equal(result[["date"]], as.POSIXct(c("2020-01-03 00:00:00", "2020-01-13 00:00:00", "2020-01-31 23:59:59")))
     expect_equal(result[["value"]], c(2, 10, 18))
     expect_equal(result[["comment"]], c(NA, NA, NA)) # comments removed deliberately
 
@@ -32,8 +32,8 @@
       "ref" = numeric(),
       "measure_name" = character(),
       "comment" = character(),
-      "event_date_or_datetime" = date()
-    )
+      "event_date_or_datetime" = lubridate::POSIXct()
+   )
 
     expect_equal(
       process_event_data_t(events),

--- a/tests/testthat/test-spcr_make_data_bundle.R
+++ b/tests/testthat/test-spcr_make_data_bundle.R
@@ -102,7 +102,7 @@
     expect_type(out[["target"]], "double")
     expect_type(out[["allowable_days_lag"]], "integer")
     expect_type(out[["measure_data"]], "list")
-    expect_s3_class(out[["last_date"]], "Date")
+    expect_s3_class(out[["last_date"]], "POSIXct")
     expect_type(out[["updated_to"]], "character")
     expect_type(out[["domain_heading"]], "logical")
 


### PR DESCRIPTION
## Please complete the following information:

1) A reference to the issue addressed by this pull-request:  
closes #96 

2) A description of the changes proposed in this PR:  
Converts internal processing of event data to POSIXct, not Date.  
Correctly sets the difftime unit to days (it was previously implicitly seconds).
Minor change to remove event data that occurs after the report cutoff datetime.  

3) Add @mentions for the people who will review this PR:  
None.

## Please confirm that you have:

- [x] Run `devtools::test()` and fixed all failing tests and warnings.
- [x] Added `suppressMessages()` to any test message which breaks the test progress UI.

Thank you for contributing to {SPCreporter}!!