### PR TITLE
Change specific version (4.4.1) of github-pages-deploy-action to v4.5.0

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -15,7 +15,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-r@v2
         with:
@@ -27,3 +27,6 @@ jobs:
           needs: check
 
       - uses: r-lib/actions/check-r-package@v2
+        with:
+          upload-snapshots: true
+          build_args: 'c("--no-manual","--compact-vignettes=gs+qpdf")'

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -22,7 +22,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-pandoc@v2
 

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Deploy to GitHub pages 🚀
         if: github.event_name != 'pull_request'
-        uses: JamesIves/github-pages-deploy-action@v4.4.1
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
           clean: false
           branch: gh-pages

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Deploy to GitHub pages 🚀
         if: github.event_name != 'pull_request'
-        uses: JamesIves/github-pages-deploy-action@v4
+        uses: JamesIves/github-pages-deploy-action@v4.5.0
         with:
           clean: false
           branch: gh-pages

--- a/README.Rmd
+++ b/README.Rmd
@@ -2,6 +2,13 @@
 output: github_document
 ---
 
+<!-- badges: start -->
+
+[![R-CMD-check](https://github.com/ThomUK/SPCreporter/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/ThomUK/SPCreporter/actions/workflows/R-CMD-check.yaml)
+
+<!-- badges: end -->
+
+
 <!-- README.md is generated from README.Rmd. Please edit that file -->
 
 ```{r setup}


### PR DESCRIPTION
Ref issue #119.

Automated pkgdown run after commit (via GitHub Actions) currently generates a warning (not an error) about moving from Node 16 to Node 20.
I believe this is addressed by moving the `JamesIves/github-pages-deploy-action` version up from the current v4.4.1 to the latest (v4.5.0).

Edit: no, this also needed a move to `actions/checkout@v4` across both `pkgdown` (gh pages deploy) and `cmd check` Actions.

This PR:
* updates the "GH Pages deploy" Action YAML file
* updates the "check release" (CMD check) Action YAML file (using `usethis::use_github_action("check-release")`)

## Please confirm that you have:

- [ ] Run `devtools::test()` and fixed all failing tests and warnings.
- [ ] Added `suppressMessages()` to any test message which breaks the test progress UI.