### PR TITLE
Handle duplicate dttms in event data

### DIFF
--- a/R/spcr_make_report.R
+++ b/R/spcr_make_report.R
@@ -207,12 +207,8 @@ make_spc_data <- function(
     measure_data
   ) {
   measure_data |>
-    # remove duplicate dttms (using `arrange` first in order to keep the higher
-    # "value" - which should be first anyway... This should only remove
-    # zeroes from the "value" column, not the time since last event!)
-    dplyr::arrange(desc(pick("value"))) |>
-    dplyr::distinct(pick("date"), .keep_all = TRUE) |>
-    dplyr::arrange(pick("date")) |>
+    # remove duplicate dttms using `slice_max` to keep just one row per date
+    dplyr::slice_max(value, n = 1, with_ties = FALSE, by = "date") |>
     NHSRplotthedots::ptd_spc(
       rebase = align_rebase_dates(rebase_dates, measure_data),
       value_field = "value",

--- a/R/spcr_make_report.R
+++ b/R/spcr_make_report.R
@@ -207,6 +207,12 @@ make_spc_data <- function(
     measure_data
   ) {
   measure_data |>
+    # remove duplicate dttms (using `arrange` first in order to keep the higher
+    # "value" - which should be first anyway... This should only remove
+    # zeroes from the "value" column, not the time since last event!)
+    dplyr::arrange(desc(pick("value"))) |>
+    dplyr::distinct(pick("date"), .keep_all = TRUE) |>
+    dplyr::arrange(pick("date")) |>
     NHSRplotthedots::ptd_spc(
       rebase = align_rebase_dates(rebase_dates, measure_data),
       value_field = "value",
@@ -259,7 +265,7 @@ make_spc_chart <- function(
         y = dplyr::last(spc_data[["y"]]),
         shape = "circle filled",
         colour = "grey65", # #a6a6a6 (matches plotthedots grey)
-        fill = "grey90",   # #e5e5e5
+        fill = NA,   # so the PTD dot can be seen
         size = 5,
         stroke = 2
       )


### PR DESCRIPTION
Refers to issue #110.

This change adds an extra step to the `make_spc_data()` function that works around a situation that currently throws an error.

@ThomUK to review/approve.

I have:

- [x] Run `devtools::test()` and fixed all failing tests and warnings.
